### PR TITLE
feat: L1PortalExecuteL2Call task implementation and rehearsals specs

### DIFF
--- a/src/improvements/interfaces/IOptimismPortal.sol
+++ b/src/improvements/interfaces/IOptimismPortal.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { Types } from "src/libraries/Types.sol";
+import { GameType } from "src/dispute/lib/LibUDT.sol";
+import { IDisputeGame } from "interfaces/dispute/IDisputeGame.sol";
+import { IDisputeGameFactory } from "interfaces/dispute/IDisputeGameFactory.sol";
+import { ISystemConfig } from "interfaces/L1/ISystemConfig.sol";
+import { ISuperchainConfig } from "interfaces/L1/ISuperchainConfig.sol";
+import { IAnchorStateRegistry } from "interfaces/dispute/IAnchorStateRegistry.sol";
+import { IProxyAdminOwnedBase } from "interfaces/L1/IProxyAdminOwnedBase.sol";
+import { IETHLockbox } from "interfaces/L1/IETHLockbox.sol";
+
+interface IOptimismPortal2 is IProxyAdminOwnedBase {
+    error OptimismPortal_Unauthorized();
+    error ContentLengthMismatch();
+    error EmptyItem();
+    error InvalidDataRemainder();
+    error InvalidHeader();
+    error ReinitializableBase_ZeroInitVersion();
+    error OptimismPortal_AlreadyFinalized();
+    error OptimismPortal_BadTarget();
+    error OptimismPortal_CallPaused();
+    error OptimismPortal_CalldataTooLarge();
+    error OptimismPortal_GasEstimation();
+    error OptimismPortal_GasLimitTooLow();
+    error OptimismPortal_ImproperDisputeGame();
+    error OptimismPortal_InvalidDisputeGame();
+    error OptimismPortal_InvalidMerkleProof();
+    error OptimismPortal_InvalidOutputRootProof();
+    error OptimismPortal_InvalidProofTimestamp();
+    error OptimismPortal_InvalidRootClaim();
+    error OptimismPortal_NoReentrancy();
+    error OptimismPortal_ProofNotOldEnough();
+    error OptimismPortal_Unproven();
+    error OptimismPortal_InvalidOutputRootIndex();
+    error OptimismPortal_InvalidSuperRootProof();
+    error OptimismPortal_InvalidOutputRootChainId();
+    error OptimismPortal_WrongProofMethod();
+    error OptimismPortal_MigratingToSameRegistry();
+    error Encoding_EmptySuperRoot();
+    error Encoding_InvalidSuperRootVersion();
+    error OutOfGas();
+    error UnexpectedList();
+    error UnexpectedString();
+
+    event Initialized(uint8 version);
+    event TransactionDeposited(address indexed from, address indexed to, uint256 indexed version, bytes opaqueData);
+    event WithdrawalFinalized(bytes32 indexed withdrawalHash, bool success);
+    event WithdrawalProven(bytes32 indexed withdrawalHash, address indexed from, address indexed to);
+    event WithdrawalProvenExtension1(bytes32 indexed withdrawalHash, address indexed proofSubmitter);
+    event ETHMigrated(address indexed lockbox, uint256 ethBalance);
+    event PortalMigrated(IETHLockbox oldLockbox, IETHLockbox newLockbox, IAnchorStateRegistry oldAnchorStateRegistry, IAnchorStateRegistry newAnchorStateRegistry);
+
+    receive() external payable;
+
+    function anchorStateRegistry() external view returns (IAnchorStateRegistry);
+    function ethLockbox() external view returns (IETHLockbox);
+    function checkWithdrawal(bytes32 _withdrawalHash, address _proofSubmitter) external view;
+    function depositTransaction(
+        address _to,
+        uint256 _value,
+        uint64 _gasLimit,
+        bool _isCreation,
+        bytes memory _data
+    )
+        external
+        payable;
+    function disputeGameBlacklist(IDisputeGame _disputeGame) external view returns (bool);
+    function disputeGameFactory() external view returns (IDisputeGameFactory);
+    function disputeGameFinalityDelaySeconds() external view returns (uint256);
+    function donateETH() external payable;
+    function superchainConfig() external view returns (ISuperchainConfig);
+    function migrateToSuperRoots(IETHLockbox _newLockbox, IAnchorStateRegistry _newAnchorStateRegistry) external;
+    function finalizeWithdrawalTransaction(Types.WithdrawalTransaction memory _tx) external;
+    function finalizeWithdrawalTransactionExternalProof(
+        Types.WithdrawalTransaction memory _tx,
+        address _proofSubmitter
+    )
+        external;
+    function finalizedWithdrawals(bytes32) external view returns (bool);
+    function guardian() external view returns (address);
+    function initialize(
+        ISystemConfig _systemConfig,
+        IAnchorStateRegistry _anchorStateRegistry,
+        IETHLockbox _ethLockbox
+    )
+        external;
+    function initVersion() external view returns (uint8);
+    function l2Sender() external view returns (address);
+    function minimumGasLimit(uint64 _byteCount) external pure returns (uint64);
+    function numProofSubmitters(bytes32 _withdrawalHash) external view returns (uint256);
+    function params() external view returns (uint128 prevBaseFee, uint64 prevBoughtGas, uint64 prevBlockNum); // nosemgrep
+    function paused() external view returns (bool);
+    function proofMaturityDelaySeconds() external view returns (uint256);
+    function proofSubmitters(bytes32, uint256) external view returns (address);
+    function proveWithdrawalTransaction(
+        Types.WithdrawalTransaction memory _tx,
+        uint256 _disputeGameIndex,
+        Types.OutputRootProof memory _outputRootProof,
+        bytes[] memory _withdrawalProof
+    )
+        external;
+    function proveWithdrawalTransaction(
+        Types.WithdrawalTransaction memory _tx,
+        IDisputeGame _disputeGameProxy,
+        uint256 _outputRootIndex,
+        Types.SuperRootProof memory _superRootProof,
+        Types.OutputRootProof memory _outputRootProof,
+        bytes[] memory _withdrawalProof
+    )
+        external;
+    function provenWithdrawals(
+        bytes32,
+        address
+    )
+        external
+        view
+        returns (IDisputeGame disputeGameProxy, uint64 timestamp);
+    function respectedGameType() external view returns (GameType);
+    function respectedGameTypeUpdatedAt() external view returns (uint64);
+    function superRootsActive() external view returns (bool);
+    function systemConfig() external view returns (ISystemConfig);
+    function upgrade(IAnchorStateRegistry _anchorStateRegistry, IETHLockbox _ethLockbox) external;
+    function version() external pure returns (string memory);
+    function migrateLiquidity() external;
+
+    function __constructor__(uint256 _proofMaturityDelaySeconds) external;
+}

--- a/src/improvements/tasks/eth/rehearsals/2025-08-11-l1-to-l2-noop/README.md
+++ b/src/improvements/tasks/eth/rehearsals/2025-08-11-l1-to-l2-noop/README.md
@@ -1,0 +1,27 @@
+# Rehearsal - L1→L2 No‑op via OptimismPortal
+
+## Objective
+Dry-run the nested SC ceremony to send a no‑op L2 call through the L1 OptimismPortal.
+
+## Steps (nested)
+1) Update addresses in `config.toml`.
+2) Simulate from the signer’s Safe:
+```sh
+just --dotenv-path $(pwd)/.env simulate council
+# or foundation / chain-governor
+```
+3) Validate
+- Tenderly state diff has no unintended changes
+- op‑txverify shows: Safe → OptimismPortal.depositTransaction → decoded inner L2 call
+- Extract domain/message hashes and match Ledger
+4) Sign
+```sh
+just --dotenv-path $(pwd)/.env sign council
+```
+5) Facilitator approve/execute per `NESTED.md`.
+
+## Notes
+- `gasLimit` must be explicit. `value` defaults to 0.
+- Use a semantic no‑op inner calldata (e.g. upgradeTo current impl) or read‑only target for rehearsal.
+
+

--- a/src/improvements/tasks/eth/rehearsals/2025-08-11-l1-to-l2-noop/config.toml
+++ b/src/improvements/tasks/eth/rehearsals/2025-08-11-l1-to-l2-noop/config.toml
@@ -1,0 +1,20 @@
+templateName = "L1PortalExecuteL2Call"
+
+# L2 chain context for address labels (fake chain for rehearsal or Sepolia)
+l2chains = [{ name = "Rehearsal Chain", chainId = 10101010101010 }]
+
+# Portal + L2 call params
+portal = "0x0000000000000000000000000000000000000001" # replace with real L1 OptimismPortal
+l2Target = "0x0000000000000000000000000000000000000002" # replace with L2 target
+l2Data = "0x" # replace with encoded no-op data (e.g., upgradeTo(currentImpl) or a read-only call)
+gasLimit = 500000
+value = 0
+isCreation = false
+
+[addresses]
+TestRehearsalCouncil = "0x0000000000000000000000000000000000000003"
+TestRehearsalFoundation = "0x0000000000000000000000000000000000000004"
+ProxyAdminOwner = "0x0000000000000000000000000000000000000005" # 2-of-2 between council and foundation
+OptimismPortal = "0x0000000000000000000000000000000000000001"
+
+

--- a/src/improvements/template/L1PortalExecuteL2Call.sol
+++ b/src/improvements/template/L1PortalExecuteL2Call.sol
@@ -1,0 +1,139 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.15;
+
+import {VmSafe} from "forge-std/Vm.sol";
+import {stdToml} from "lib/forge-std/src/StdToml.sol";
+
+import {MultisigTaskPrinter} from "src/libraries/MultisigTaskPrinter.sol";
+import {Action} from "src/libraries/MultisigTypes.sol";
+
+import {IOptimismPortal2} from "src/improvements/interfaces/IOptimismPortal.sol";
+
+
+import {SimpleTaskBase} from "src/improvements/tasks/types/SimpleTaskBase.sol";
+
+/// @notice Template to execute an L2 call via the L1 Optimism Portal from a nested L1 Safe.
+/// Sends an L2 transaction using OptimismPortal.depositTransaction with config-driven params.
+contract L1PortalExecuteL2Call is SimpleTaskBase {
+    using stdToml for string;
+
+    // -------- Config inputs --------
+    address public portal; // L1 OptimismPortal address
+    address public l2Target; // L2 target address
+    bytes public l2Data; // Inner L2 calldata
+    uint256 public valueWei; // ETH value to forward to L2 (defaults to 0)
+    uint64 public gasLimit; // L2 gas limit (required)
+    bool public isCreation; // Whether to create a contract on L2 (defaults to false)
+
+    /// @notice Default Safe name. Can be overridden via `safeAddressString` in config.toml.
+    function safeAddressString() public pure override returns (string memory) {
+        return "ProxyAdminOwner";
+    }
+
+    /// @notice The contracts expected to have storage writes during execution.
+    /// Allowlist the OptimismPortal since it will mutate state (queue/event) on deposit.
+    function _taskStorageWrites() internal pure override returns (string[] memory) {
+        string[] memory _storageWrites = new string[](1);
+        _storageWrites[0] = "OptimismPortal";
+        return _storageWrites;
+    }
+
+    /// @notice The contracts expected to have balance changes during execution.
+    /// Allowlist the OptimismPortal to receive ETH (value) in the deposit call.
+    function _taskBalanceChanges() internal view override returns (string[] memory) {
+        string[] memory _balanceChanges = new string[](1);
+        _balanceChanges[0] = "OptimismPortal";
+        return _balanceChanges;
+    }
+
+    /// @notice Parse config and initialize template variables.
+    /// Expected TOML keys:
+    /// - portal: address (L1 OptimismPortal) OR addresses.OptimismPortal in [addresses]
+    /// - l2Target: address (L2 target address)
+    /// - l2Data: hex string (e.g. 0x1234...)
+    /// - gasLimit: uint (will be cast to uint64)
+    /// - value: uint (optional, default 0)
+    /// - isCreation: bool (optional, default false)
+    function _templateSetup(string memory _taskConfigFilePath, address) internal override {
+        string memory _toml = vm.readFile(_taskConfigFilePath);
+
+        // Resolve portal from registry first if available, else read explicit field.
+        try simpleAddrRegistry.get("OptimismPortal") returns (address p) {
+            portal = p;
+        } catch {
+            portal = _toml.readAddress(".portal");
+        }
+        require(portal != address(0), "portal must be set (addresses.OptimismPortal or .portal)");
+
+        l2Target = _toml.readAddress(".l2Target");
+        require(l2Target != address(0), "l2Target must be set");
+
+        // Read hex string and parse to bytes.
+        string memory _dataHex = _toml.readString(".l2Data");
+        l2Data = vm.parseBytes(_dataHex);
+        require(l2Data.length > 0, "l2Data must be set");
+
+        uint256 _gasLimitTmp = _toml.readUint(".gasLimit");
+        require(_gasLimitTmp > 0 && _gasLimitTmp <= type(uint64).max, "invalid gasLimit");
+        gasLimit = uint64(_gasLimitTmp);
+
+        // Optional fields
+        valueWei = 0;
+        try vm.parseTomlString(_toml, ".value") returns (string memory) {
+            // If present as string, prefer numeric below; keep compatibility.
+        } catch {
+            try vm.parseTomlUint(_toml, ".value") returns (uint256 _v) {
+                valueWei = _v;
+            } catch {}
+        }
+
+        isCreation = false;
+        try vm.parseTomlBool(_toml, ".isCreation") returns (bool _b) {
+            isCreation = _b;
+        } catch {}
+    }
+
+    /// @notice Build the portal deposit action. WARNING: State changes here are reverted after capture.
+    function _build(address) internal override {
+        // Record the L1 portal call with value for action extraction.
+        IOptimismPortal2(portal).depositTransaction{value: valueWei}(
+            l2Target,
+            valueWei,
+            gasLimit,
+            isCreation,
+            l2Data
+        );
+    }
+
+    /// @notice Validate that exactly one action to the portal with the expected calldata and value was captured.
+    function _validate(VmSafe.AccountAccess[] memory, Action[] memory _actions, address) internal override {
+        bytes memory _expected = abi.encodeWithSelector(
+            IOptimismPortal2.depositTransaction.selector,
+            l2Target,
+            valueWei,
+            gasLimit,
+            isCreation,
+            l2Data
+        );
+
+        bool _found;
+        uint256 _matches;
+        for (uint256 _i = 0; _i < _actions.length; _i++) {
+            if (_actions[_i].target == portal && _actions[_i].value == valueWei) {
+                if (keccak256(_actions[_i].arguments) == keccak256(_expected)) {
+                    _found = true;
+                    _matches++;
+                }
+            }
+        }
+        require(_found && _matches == 1, "expected one portal deposit action");
+        MultisigTaskPrinter.printTitle("Validated portal deposit action");
+    }
+
+    /// @notice No code exceptions required for this template.
+    function _getCodeExceptions() internal view override returns (address[] memory) {
+        return new address[](0);
+    }
+}
+
+


### PR DESCRIPTION
### Description
- Add L1→L2 portal execution template
  - `src/improvements/template/L1PortalExecuteL2Call.sol`
  - Uses full `IOptimismPortal2` (depositTransaction) to dispatch an L2 call from an L1 Safe
  - Config-driven params via `config.toml`: `portal`, `l2Target`, `l2Data`, `gasLimit` (uint64), `value` (default 0), `isCreation` (default false)
  - Extends `SimpleTaskBase` for L1 multisig flows; `safeAddressString()` defaults to `ProxyAdminOwner`
  - Validation: asserts exactly one portal call with expected calldata/value; allowlists storage/balance changes for `OptimismPortal`
- Add full portal interface
  - `src/improvements/interfaces/IOptimismPortal.sol` (complete `IOptimismPortal2`)
- Scaffold nested rehearsal task
  - `src/improvements/tasks/eth/rehearsals/2025-08-11-l1-to-l2-noop/`
  - `config.toml` placeholders and signer `README.md` with simulate/validate/sign steps

### Tests
- Template-level validation enforces encoded calldata and a single portal action
- Manual simulate run expected:
  - Tenderly diff: no unintended changes; shows portal call
  - op-txverify link generated by task flow; nested path visible
- Follow-up: add Foundry unit test for ABI encoding of `depositTransaction` with sample inputs and a golden-action count assertion

### Additional context
- Aligns with expected deliverables:
  - New task template for nested L1→L2 execution via SC Safe
  - Preps for a separate PR in `op-txverify` to decode portal calls and render inner L2 calldata
- Safety/UX:
  - `gasLimit` constrained to uint64 and required
  - `value` defaults to 0
  - Works with `nested.just`/`NESTED.md` ceremony and SC signer checklist